### PR TITLE
(#37) custom arguments are split at the first colon, only

### DIFF
--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -72,7 +72,8 @@ describe('When getting multiple custom script input arguments from the action', 
     when(fakeGetMultilineInput).calledWith('arguments').mockReturnValue([
       `string-parameter: 'value'`,
       'numeric-parameter: 3',
-      'boolean-parameter: true'
+      'boolean-parameter: true',
+      'url: \'https://www.google.com\''
     ]);
   });
 
@@ -86,6 +87,10 @@ describe('When getting multiple custom script input arguments from the action', 
 
   test('it should return the argument for a custom boolean parameter', () => {
     expect(action.getInputs().scriptArguments).toContainEqual(new CakeArgument('boolean-parameter', 'true'));
+  });
+
+  test('it should return the argument for a custom string parameter containing a colon', () => {
+    expect(action.getInputs().scriptArguments).toContainEqual(new CakeArgument('url', '\'https://www.google.com\''));
   });
 });
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -60,6 +60,8 @@ function containsArgumentDefinition(line: string): boolean {
 }
 
 function parseNameAndValue(line: string): [string, string] {
-  const nameValue = line.split(':');
-  return [nameValue[0].trim(), nameValue[1].trim()];
+  const idx = line.indexOf(':');
+  const name = line.substring(0, idx);
+  const value = line.substring(idx + 1);
+  return [name.trim(), value.trim()];
 }


### PR DESCRIPTION
fixes #37