### PR TITLE
Gets the latest version of Cake from GitHub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,24 @@ jobs:
           cake-version: tool-manifest
           script-path: ${{ env.script-directory }}/build.cake
           target: Test-Cake-Version
+      - name: Get the latest Cake release from GitHub
+        id: get-latest-cake-release
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/cake-build/cake/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set the EXPECTED_CAKE_VERSION environment variable
+        shell: bash
+        run: |
+          version=$(echo ${{ fromJson(steps.get-latest-cake-release.outputs.data).tag_name }} | sed 's/v//')
+          echo "EXPECTED_CAKE_VERSION=$version" >> $GITHUB_ENV
+      - name: Run with the latest Cake version
+        uses: ./
+        with:
+          cake-version: latest
+          script-path: ${{ env.script-directory }}/build.cake
+          target: Test-Cake-Version
       - name: Run automatic bootstrapping of Cake modules (Cake >= 1.0.0)
         uses: ./
         with:

--- a/__tests__/cakeRelease.test.ts
+++ b/__tests__/cakeRelease.test.ts
@@ -1,0 +1,112 @@
+import * as http from '@actions/http-client';
+import * as cakeRelease from '../src/cakeRelease';
+
+describe('When retrieving the latest Cake version', () => {
+  beforeAll(async () => {
+    jest
+      .spyOn(http.HttpClient.prototype, 'getJson')
+      .mockImplementation(async () => ({
+        statusCode: 200,
+        result: {
+          tag_name: 'v1.0.0'
+        },
+        headers: {}
+      }));
+  });
+
+  test('it should return the latest version number from GitHub', async () => {
+    expect(await cakeRelease.getLatestVersion()).toBe('1.0.0');
+  });
+});
+
+describe('When retrieving the latest Cake version without the \'v\' prefix', () => {
+  beforeAll(async () => {
+    jest
+      .spyOn(http.HttpClient.prototype, 'getJson')
+      .mockImplementation(async () => ({
+        statusCode: 200,
+        result: {
+          tag_name: '1.0.0'
+        },
+        headers: {}
+      }));
+  });
+
+  test('it should return the latest version number from GitHub', async () => {
+    expect(await cakeRelease.getLatestVersion()).toBe('1.0.0');
+  });
+});
+
+describe('When failing to retrieve the latest Cake version due to a GitHub error', () => {
+  beforeAll(async () => {
+    jest
+      .spyOn(http.HttpClient.prototype, 'getJson')
+      .mockImplementation(async () => ({
+        statusCode: 500,
+        result: {},
+        headers: {}
+      }));
+  });
+
+  test('it should return null', async () => {
+    expect(await cakeRelease.getLatestVersion()).toBeNull();
+  });
+
+  test('it should log the fact that the GitHub API returned an error', async () => {
+    const log = jest.spyOn(console, 'log');
+    await cakeRelease.getLatestVersion();
+    expect(log).toHaveBeenCalledWith('Could not determine the latest version of Cake. GitHub returned status code 500');
+  });
+});
+
+describe('When failing to retrieve the latest Cake version due to an empty response from GitHub', () => {
+  beforeAll(async () => {
+    jest
+      .spyOn(http.HttpClient.prototype, 'getJson')
+      .mockImplementation(async () => ({
+        statusCode: 200,
+        result: {},
+        headers: {}
+      }));
+  });
+
+  test('it should return null', async () => {
+    expect(await cakeRelease.getLatestVersion()).toBeNull();
+  });
+});
+
+describe('When failing to retrieve the latest Cake version due to a missing tag name in the GitHub response', () => {
+  beforeAll(async () => {
+    jest
+      .spyOn(http.HttpClient.prototype, 'getJson')
+      .mockImplementation(async () => ({
+        statusCode: 200,
+        result: {
+          tag_name: null
+        },
+        headers: {}
+      }));
+  });
+
+  test('it should return null', async () => {
+    expect(await cakeRelease.getLatestVersion()).toBeNull();
+  });
+});
+
+describe('When failing to retrieve the latest Cake version due to an empty tag name in the GitHub response', () => {
+  beforeAll(async () => {
+    jest
+      .spyOn(http.HttpClient.prototype, 'getJson')
+      .mockImplementation(async () => ({
+        statusCode: 200,
+        result: {
+          tag_name: ''
+        },
+        headers: {}
+      }));
+  });
+
+  test('it should return null', async () => {
+    expect(await cakeRelease.getLatestVersion()).toBeNull();
+  });
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -4150,6 +4150,72 @@ exports.CakeSwitch = CakeSwitch;
 
 /***/ }),
 
+/***/ 3040:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getLatestVersion = void 0;
+const http = __importStar(__nccwpck_require__(6255));
+function getLatestVersion() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const release = yield getLatestCakeReleaseFromGitHub();
+        return extractVersionNumber(release);
+    });
+}
+exports.getLatestVersion = getLatestVersion;
+function getLatestCakeReleaseFromGitHub() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const client = new http.HttpClient('cake-build/cake-action');
+        const response = yield client.getJson('https://api.github.com/repos/cake-build/cake/releases/latest');
+        if (response.statusCode != 200) {
+            console.log(`Could not determine the latest version of Cake. GitHub returned status code ${response.statusCode}`);
+            return null;
+        }
+        return response.result;
+    });
+}
+function extractVersionNumber(release) {
+    var _a;
+    return ((_a = release === null || release === void 0 ? void 0 : release.tag_name) === null || _a === void 0 ? void 0 : _a.replace(/^v/, '')) || null;
+}
+
+
+/***/ }),
+
 /***/ 4574:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -4191,7 +4257,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.install = void 0;
 const dotnet = __importStar(__nccwpck_require__(9870));
 const toolsDirectory_1 = __nccwpck_require__(6745);
+const cakeRelease_1 = __nccwpck_require__(3040);
 function install(toolsDir, version) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         switch (version === null || version === void 0 ? void 0 : version.version) {
             case 'tool-manifest':
@@ -4199,7 +4267,7 @@ function install(toolsDir, version) {
                 break;
             case 'latest':
             case undefined:
-                yield installCakeLocalTool(toolsDir);
+                yield installCakeLocalTool(toolsDir, (_a = yield (0, cakeRelease_1.getLatestVersion)()) !== null && _a !== void 0 ? _a : undefined);
                 break;
             case 'specific':
                 yield installCakeLocalTool(toolsDir, version.number);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.9.1",
         "@actions/exec": "^1.0.1",
+        "@actions/http-client": "^2.0.1",
         "@actions/io": "^1.0.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.0.1",
+    "@actions/http-client": "^2.0.1",
     "@actions/io": "^1.0.1"
   },
   "devDependencies": {

--- a/src/cakeRelease.ts
+++ b/src/cakeRelease.ts
@@ -1,0 +1,26 @@
+import * as http from '@actions/http-client';
+
+export async function getLatestVersion(): Promise<string | null> {
+  const release = await getLatestCakeReleaseFromGitHub();
+  return extractVersionNumber(release);
+}
+
+async function getLatestCakeReleaseFromGitHub(): Promise<GitHubRelease | null> {
+  const client = new http.HttpClient('cake-build/cake-action');
+  const response = await client.getJson<GitHubRelease>('https://api.github.com/repos/cake-build/cake/releases/latest');
+
+  if (response.statusCode != 200) {
+    console.log(`Could not determine the latest version of Cake. GitHub returned status code ${response.statusCode}`);
+    return null;
+  }
+
+  return response.result;
+}
+
+function extractVersionNumber(release: GitHubRelease | null): string | null {
+  return release?.tag_name?.replace(/^v/, '') || null;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+}

--- a/src/cakeTool.ts
+++ b/src/cakeTool.ts
@@ -1,6 +1,7 @@
 import * as dotnet from './dotnet';
 import { ToolsDirectory } from './toolsDirectory';
 import { CakeVersion } from './action';
+import { getLatestVersion } from './cakeRelease';
 
 export async function install(toolsDir?: ToolsDirectory, version?: CakeVersion) {
   switch (version?.version) {
@@ -9,7 +10,7 @@ export async function install(toolsDir?: ToolsDirectory, version?: CakeVersion) 
       break;
     case 'latest':
     case undefined:
-      await installCakeLocalTool(toolsDir);
+      await installCakeLocalTool(toolsDir, await getLatestVersion() ?? undefined);
       break;
     case 'specific':
       await installCakeLocalTool(toolsDir, version.number);


### PR DESCRIPTION
This PR resolves #55 by fetching the version of the latest `Cake.Tool` release through the [GitHub REST API](https://docs.github.com/en/rest/releases/releases).