### PR TITLE
GH71: Run the action and CI on Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Get the sources
         uses: actions/checkout@v1
-      - name: Install Node 20
+      - name: Install Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Restore the dependencies
         run: npm install
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Get the sources
         uses: actions/checkout@v1
-      - name: Install Node 20
+      - name: Install Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install the .NET 6 SDK
         uses: actions/setup-dotnet@v4
         with:
@@ -168,10 +168,10 @@ jobs:
     steps:
       - name: Get the sources
         uses: actions/checkout@v1
-      - name: Install Node 20
+      - name: Install Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install the .NET 8 SDK
         uses: actions/setup-dotnet@v4
         with:
@@ -223,10 +223,10 @@ jobs:
     steps:
       - name: Get the sources
         uses: actions/checkout@v1
-      - name: Install Node 20
+      - name: Install Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install the .NET 10 SDK (Preview)
         uses: actions/setup-dotnet@v4
         with:

--- a/action.yml
+++ b/action.yml
@@ -38,5 +38,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
- Declare `runs.using: node24` in action.yml per GitHub Actions Node 20 deprecation
- Align build and test workflows with Node 24 via setup-node
- fixes #71